### PR TITLE
fix "undefined method `each' for #<String:0x...>" with newish ruby

### DIFF
--- a/lib/facter/getent.rb
+++ b/lib/facter/getent.rb
@@ -8,7 +8,7 @@ require 'facter'
 # Returns passwd entry for all users using "getent".
 Facter.add(:getent_passwd) do
   users = ''
-  %x{/usr/bin/getent passwd}.each do |n|
+  %x{/usr/bin/getent passwd}.split("\n").each do |n|
      users << n.chomp+'|'
   end
   setcode do
@@ -19,7 +19,7 @@ end
 # Returns groups entry for all groups using "getent".
 Facter.add(:getent_group) do
   groups = ''
-  %x{/usr/bin/getent group}.each do |n|
+  %x{/usr/bin/getent group}.split("\n").each do |n|
      groups << n.chomp+'|'
   end
   setcode do


### PR DESCRIPTION
successfully tested with

ruby 1.8.5 (2006-08-25)
ruby 1.8.7 (2008-08-11 patchlevel 72)
ruby 1.8.7 (2010-08-16 patchlevel 302)
ruby 1.9.3p194 (2012-04-20 revision 35410)
ruby 2.1.5p273 (2014-11-13)